### PR TITLE
ci: notify platform frontend on SDK docs update

### DIFF
--- a/.github/workflows/notify-platform-docs-update.yml
+++ b/.github/workflows/notify-platform-docs-update.yml
@@ -1,0 +1,22 @@
+name: Notify Platform Frontend on SDK docs update
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - "docs/QUICKSTART.md"
+      - "docs/API_REFERENCE.md"
+      - "docs/WORKFLOW.md"
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch sdk-docs-updated event to Platform Frontend
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PLATFORM_REPO_TOKEN }}
+          repository: elith-co-jp/prd-genflux-platform-frontend
+          event-type: sdk-docs-updated
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Summary
- `docs/QUICKSTART.md`, `docs/API_REFERENCE.md`, `docs/WORKFLOW.md` が develop に push されたとき、Platform Frontend repo に `repository_dispatch` (`sdk-docs-updated`) イベントを送信するワークフロー追加
- Platform Frontend 側で自動的に JA/EN ドキュメントが同期・翻訳される

## Test plan
- [ ] `docs/` 配下の対象ファイルを変更して develop に push → Platform Frontend Actions がトリガーされる
- [ ] 対象外ファイルの変更では発火しない

## Prerequisites
- `PLATFORM_REPO_TOKEN` を Repository Secrets に設定する必要あり（Platform Frontend repo への `contents: write` 権限付き Fine-grained PAT）

🤖 Generated with [Claude Code](https://claude.com/claude-code)