### PR TITLE
docs: README にトライアルクレジット 20 クレジット付与の案内を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ except JobFailedError as e:
 | `GENFLUX_ENVIRONMENT` | `"local"` / `"dev"` / `"prod"` | `"prod"` |
 | `GENFLUX_API_BASE_URL` | ベース URL の上書き（最優先） | — |
 
-API Key は [GENFLUX Platform](https://www.platform.genflux.jp/) から発行してください。
+API Key は [GENFLUX Platform](https://www.platform.genflux.jp/) から発行してください。<br>
+**📝 無料トライアル:** アカウント作成時に **20 クレジット** が自動付与されます。SDK の機能を今すぐ無料でお試しいただけます。
 
 ## サポート
 


### PR DESCRIPTION
Closes #27

## 概要

Platform Backend 側でトライアルクレジットが 10 → 20 に変更されたことに伴い、`README.md` の設定セクションにアカウント作成時の 20 クレジット自動付与の案内を追記し、ドキュメントの整合性を確保する。

## 変更内容

- `README.md` — 設定セクション（API Key 発行案内の直下）に無料トライアルとして **20 クレジット** が自動付与される旨を追記
- `docs/QUICKSTART.md`、`docs/API_REFERENCE.md`、`docs/BACKEND_API_REFERENCE.md`、`docs/EXAMPLES.md` — クレジット数の記載なし、変更不要
- PyPI / GitHub リリースページ — README.md の変更が次回リリース時に自動反映

## チェックリスト

### 基本
- [ ] テストを追加/更新した（必要な場合）
- [ ] `ruff check` / `ruff format` をパスした
- [ ] `pyright` の型チェックをパスした

### 公開 API の変更
- [ ] 公開 API（`__init__.py` の `__all__`）を変更した場合、docstring を更新した
- [ ] API Reference を再生成した: `make docs`
- [ ] llms.txt を再生成した: `make llms-txt`

### ドキュメント（自動生成物 — 直接編集禁止）
- [x] `docs/API_REFERENCE.md` を直接編集していない
- [x] `docs/DEVELOPER_API_REFERENCE.md` を直接編集していない
- [x] `llms.txt` を直接編集していない
- [x] `llms-full.txt` を直接編集していない
- [x] ワークフロー/使い方の変更がある場合、関連ドキュメントを更新した

## 関連 Issue / PR

- #27
- 関連: elith-co-jp/prd-genflux-platform-backend#76
- 関連: elith-co-jp/prd-genflux-platform-frontend#55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation（ドキュメンテーション）**
  * API Key取得に関するガイダンスを更新しました。
  * 無料トライアル情報を追加：アカウント作成時に20クレジットが自動付与されます。
  * SDKの機能を無料で試用できることが明記されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->